### PR TITLE
fix: fetch all merge request discussion pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gitlab-mcp-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gitlab-mcp-cli",
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dependencies": {
         "@modelcontextprotocol/sdk": "1.29.0",
         "dotenv": "17.4.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gitlab-mcp-cli",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "GitLab MCP server CLI with read-only defaults and guarded write operations.",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/tools/mergeRequests.ts
+++ b/src/tools/mergeRequests.ts
@@ -116,6 +116,85 @@ export function findResolvableDiscussionNoteId(discussion: JsonMap): number | nu
   return null;
 }
 
+interface MergeRequestDiscussionPage {
+  readonly pagination: {
+    readonly page?: number;
+    readonly perPage?: number;
+    readonly nextPage?: number;
+    readonly prevPage?: number;
+    readonly total?: number;
+    readonly totalPages?: number;
+    readonly nextLink?: string;
+  };
+}
+
+export async function collectMergeRequestDiscussions(
+  client: Pick<ToolDeps["client"], "getJson">,
+  args: {
+    readonly projectId: string;
+    readonly mergeRequestIid: number;
+    readonly page?: number;
+    readonly perPage: number;
+    readonly maxPages: number;
+  }
+): Promise<{
+  readonly items: readonly JsonMap[];
+  readonly pagination: {
+    readonly page?: number;
+    readonly perPage: number;
+    readonly nextPage?: number;
+    readonly prevPage?: number;
+    readonly total?: number;
+    readonly totalPages?: number;
+    readonly nextLink?: string;
+    readonly pagesFetched: number;
+    readonly autoPaginated: boolean;
+  };
+}> {
+  const path = `/projects/${encodeURIComponent(args.projectId)}/merge_requests/${args.mergeRequestIid}/discussions`;
+  const autoPaginated = args.page === undefined;
+  let currentPage = args.page ?? 1;
+  let pagesFetched = 0;
+  let lastPage: MergeRequestDiscussionPage | null = null;
+  const items: JsonMap[] = [];
+
+  do {
+    const response = await client.getJson<JsonMap[]>(path, {
+      query: {
+        page: currentPage,
+        per_page: args.perPage
+      }
+    });
+
+    items.push(...response.data);
+    lastPage = {
+      pagination: response.pagination
+    };
+    pagesFetched += 1;
+
+    if (!autoPaginated || !response.pagination.nextPage || pagesFetched >= args.maxPages) {
+      break;
+    }
+
+    currentPage = response.pagination.nextPage;
+  } while (true);
+
+  return {
+    items,
+    pagination: {
+      page: args.page ?? 1,
+      perPage: args.perPage,
+      nextPage: lastPage?.pagination.nextPage,
+      prevPage: lastPage?.pagination.prevPage,
+      total: lastPage?.pagination.total ?? items.length,
+      totalPages: lastPage?.pagination.totalPages,
+      nextLink: lastPage?.pagination.nextLink,
+      pagesFetched,
+      autoPaginated
+    }
+  };
+}
+
 export function registerMergeRequestTools(deps: ToolDeps): void {
   registerTool(deps, {
     name: "gitlab_list_merge_requests",
@@ -252,20 +331,28 @@ export function registerMergeRequestTools(deps: ToolDeps): void {
   registerTool(deps, {
     name: "gitlab_get_merge_request_discussions",
     title: "Get Merge Request Discussions",
-    description: "List all discussions for a merge request.",
+    description: "List discussions for a merge request. Auto-fetches later pages by default so older notes are included.",
     safety: "read-only",
     inputSchema: {
       project_id: z.string().trim().min(1),
-      merge_request_iid: z.number().int().positive()
+      merge_request_iid: z.number().int().positive(),
+      page: z.number().int().positive().optional(),
+      per_page: z.number().int().positive().max(100).optional().default(100),
+      max_pages: z.number().int().positive().max(20).optional().default(10)
     },
     handler: async (args, { client, requireProject }) => {
       await requireProject(args.project_id);
-      const response = await client.getJson<JsonMap[]>(
-        `/projects/${encodeURIComponent(args.project_id)}/merge_requests/${args.merge_request_iid}/discussions`
-      );
+      const response = await collectMergeRequestDiscussions(client, {
+        projectId: args.project_id,
+        mergeRequestIid: args.merge_request_iid,
+        page: args.page,
+        perPage: args.per_page,
+        maxPages: args.max_pages
+      });
 
       return {
-        items: response.data,
+        items: response.items,
+        pagination: response.pagination,
         content_is_untrusted: true
       };
     }

--- a/tests/merge-request-discussions.test.ts
+++ b/tests/merge-request-discussions.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+
+import { collectMergeRequestDiscussions } from "../src/tools/mergeRequests.js";
+
+describe("collectMergeRequestDiscussions", () => {
+  it("auto-fetches later discussion pages so older notes are not skipped", async () => {
+    const calls: Array<{ page?: number; per_page?: number }> = [];
+    const client = {
+      async getJson<T>(_path: string, options?: { query?: Record<string, unknown> }) {
+        const page = typeof options?.query?.page === "number" ? options.query.page : 1;
+        const perPage = typeof options?.query?.per_page === "number" ? options.query.per_page : undefined;
+        calls.push({
+          page,
+          per_page: perPage
+        });
+
+        if (page === 1) {
+          return {
+            data: [{ id: "discussion-1", notes: [{ id: 101 }] }] as T,
+            headers: new Headers(),
+            pagination: {
+              page: 1,
+              perPage: perPage,
+              nextPage: 2,
+              total: 2,
+              totalPages: 2
+            }
+          };
+        }
+
+        return {
+          data: [{ id: "discussion-2", notes: [{ id: 387634 }, { id: 387704 }] }] as T,
+          headers: new Headers(),
+          pagination: {
+            page: 2,
+            perPage: perPage,
+            total: 2,
+            totalPages: 2
+          }
+        };
+      }
+    };
+
+    const result = await collectMergeRequestDiscussions(client, {
+      projectId: "developers/SGFramework",
+      mergeRequestIid: 373,
+      perPage: 100,
+      maxPages: 10
+    });
+
+    expect(calls).toEqual([
+      { page: 1, per_page: 100 },
+      { page: 2, per_page: 100 }
+    ]);
+    expect(result.items).toHaveLength(2);
+    expect(result.items[1]).toMatchObject({
+      id: "discussion-2",
+      notes: [{ id: 387634 }, { id: 387704 }]
+    });
+    expect(result.pagination).toMatchObject({
+      page: 1,
+      perPage: 100,
+      total: 2,
+      totalPages: 2,
+      pagesFetched: 2,
+      autoPaginated: true
+    });
+  });
+
+  it("keeps single-page behavior when a specific page is requested", async () => {
+    const calls: Array<{ page?: number; per_page?: number }> = [];
+    const client = {
+      async getJson<T>(_path: string, options?: { query?: Record<string, unknown> }) {
+        const page = typeof options?.query?.page === "number" ? options.query.page : 1;
+        const perPage = typeof options?.query?.per_page === "number" ? options.query.per_page : undefined;
+        calls.push({
+          page,
+          per_page: perPage
+        });
+
+        return {
+          data: [{ id: `discussion-${page}` }] as T,
+          headers: new Headers(),
+          pagination: {
+            page,
+            perPage,
+            nextPage: 3,
+            total: 3,
+            totalPages: 3
+          }
+        };
+      }
+    };
+
+    const result = await collectMergeRequestDiscussions(client, {
+      projectId: "developers/SGFramework",
+      mergeRequestIid: 373,
+      page: 2,
+      perPage: 50,
+      maxPages: 10
+    });
+
+    expect(calls).toEqual([{ page: 2, per_page: 50 }]);
+    expect(result.items).toEqual([{ id: "discussion-2" }]);
+    expect(result.pagination).toMatchObject({
+      page: 2,
+      perPage: 50,
+      nextPage: 3,
+      pagesFetched: 1,
+      autoPaginated: false
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- fix merge request discussions retrieval so later API pages are fetched
- add bounded auto-pagination by default for discussion listing
- keep optional manual single-page access via `page`
- return pagination metadata with the discussion response
- add regression tests covering missing later-page notes

## Problem
The merge request discussions tool only fetched the first page from the GitLab discussions endpoint. On merge requests with enough activity to span multiple pages, existing notes visible in the GitLab UI could be missing from MCP responses.

## Solution
The discussions retrieval path now follows GitLab pagination headers and collects additional pages until there are no more results or the configured page limit is reached. This preserves explicit single-page access when a caller provides `page`.

## Validation
- `npm run build`
- `npm test`