### PR TITLE
Handle missing MergeRequest.approvalsLeft in project dashboard GraphQL query

### DIFF
--- a/src/tools/projectDashboard.ts
+++ b/src/tools/projectDashboard.ts
@@ -36,7 +36,7 @@ interface ProjectDashboardQueryResult {
   readonly project?: GraphQLProjectDashboard | null;
 }
 
-const PROJECT_DASHBOARD_QUERY = `
+const PROJECT_DASHBOARD_QUERY_WITH_APPROVALS = `
   query GetProjectDashboard(
     $projectPath: ID!
     $mergeRequestLimit: Int!
@@ -116,6 +116,94 @@ const PROJECT_DASHBOARD_QUERY = `
     }
   }
 `;
+
+const PROJECT_DASHBOARD_QUERY_BASE = `
+  query GetProjectDashboard(
+    $projectPath: ID!
+    $mergeRequestLimit: Int!
+    $issueLimit: Int!
+    $pipelineLimit: Int!
+    $assigneeLimit: Int!
+  ) {
+    project(fullPath: $projectPath) {
+      id
+      name
+      fullPath
+      webUrl
+      description
+      archived
+      visibility
+      lastActivityAt
+      repository {
+        rootRef
+        empty
+      }
+      mergeRequests(state: opened, first: $mergeRequestLimit, sort: UPDATED_DESC) {
+        count
+        nodes {
+          iid
+          title
+          webUrl
+          draft
+          updatedAt
+          detailedMergeStatus
+          headPipeline {
+            status
+            detailedStatus {
+              text
+              label
+              group
+              icon
+            }
+          }
+        }
+      }
+      issues(state: opened, first: $issueLimit, sort: UPDATED_DESC) {
+        count
+        nodes {
+          iid
+          title
+          reference
+          webUrl
+          dueDate
+          updatedAt
+          assignees(first: $assigneeLimit) {
+            nodes {
+              username
+              name
+              webUrl
+            }
+          }
+        }
+      }
+      pipelines(first: $pipelineLimit) {
+        count
+        nodes {
+          iid
+          path
+          status
+          ref
+          sha
+          updatedAt
+          detailedStatus {
+            text
+            label
+            group
+            icon
+          }
+        }
+      }
+    }
+  }
+`;
+
+export function shouldRetryWithoutApprovalFields(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return /Field 'approvalsLeft' doesn't exist on type 'MergeRequest'/i.test(error.message);
+}
 
 export function summarizeProjectDashboard(project: GraphQLProjectDashboard): JsonMap {
   const mergeRequests = takeNodes(project.mergeRequests).map(summarizeMergeRequest);
@@ -240,16 +328,31 @@ export function registerProjectDashboardTools(deps: ToolDeps): void {
         throw new Error("GitLab did not return a project path that can be used for GraphQL queries.");
       }
 
-      const response = await graphqlClient.query<ProjectDashboardQueryResult>(
-        PROJECT_DASHBOARD_QUERY,
-        {
-          projectPath,
-          mergeRequestLimit: args.merge_request_limit,
-          issueLimit: args.issue_limit,
-          pipelineLimit: args.pipeline_limit,
-          assigneeLimit: args.assignee_limit
+      const queryVariables = {
+        projectPath,
+        mergeRequestLimit: args.merge_request_limit,
+        issueLimit: args.issue_limit,
+        pipelineLimit: args.pipeline_limit,
+        assigneeLimit: args.assignee_limit
+      };
+
+      let response: ProjectDashboardQueryResult;
+
+      try {
+        response = await graphqlClient.query<ProjectDashboardQueryResult>(
+          PROJECT_DASHBOARD_QUERY_WITH_APPROVALS,
+          queryVariables
+        );
+      } catch (error) {
+        if (!shouldRetryWithoutApprovalFields(error)) {
+          throw error;
         }
-      );
+
+        response = await graphqlClient.query<ProjectDashboardQueryResult>(
+          PROJECT_DASHBOARD_QUERY_BASE,
+          queryVariables
+        );
+      }
 
       const resultProject = response.project ?? null;
 

--- a/tests/project-dashboard.test.ts
+++ b/tests/project-dashboard.test.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it } from "vitest";
 
 import { isBlockedMergeStatus } from "../src/tools/intelligence.js";
-import { summarizeProjectDashboard } from "../src/tools/projectDashboard.js";
+import {
+  shouldRetryWithoutApprovalFields,
+  summarizeProjectDashboard
+} from "../src/tools/projectDashboard.js";
 
 describe("isBlockedMergeStatus", () => {
   it("treats GraphQL-style uppercase merge statuses as blocked statuses", () => {
@@ -12,6 +15,21 @@ describe("isBlockedMergeStatus", () => {
 });
 
 describe("summarizeProjectDashboard", () => {
+  it("retries with a compatibility query when approvalsLeft is not in the MergeRequest schema", () => {
+    expect(
+      shouldRetryWithoutApprovalFields(
+        new Error(
+          "GitLab GraphQL query failed: Field 'approvalsLeft' doesn't exist on type 'MergeRequest'."
+        )
+      )
+    ).toBe(true);
+    expect(
+      shouldRetryWithoutApprovalFields(
+        new Error("GitLab GraphQL query failed: Field 'milestone' doesn't exist on type 'Issue'.")
+      )
+    ).toBe(false);
+  });
+
   it("marks a clean active project as healthy", () => {
     const summary = summarizeProjectDashboard({
       id: "gid://gitlab/Project/1",


### PR DESCRIPTION
## Summary

Make `gitlab_get_project_dashboard` compatible with GitLab instances where `MergeRequest.approvalsLeft` is not available.

## Changes

- Keep the existing dashboard query with approval data as the primary path
- Detect GraphQL schema failures caused by missing `approvalsLeft`
- Retry with a compatibility query that omits approval-specific fields
- Add test coverage for the fallback condition

## Why

Some GitLab instances do not expose approval-related GraphQL fields on `MergeRequest`. Previously this caused the entire dashboard tool to fail instead of returning a partial but useful dashboard.

## Result

`gitlab_get_project_dashboard` now degrades gracefully and still returns project health, open issues, merge requests, and pipeline highlights when approval fields are unavailable. Closes #11 

## Validation

- Project build passed
- `tests/project-dashboard.test.ts` passed
