### PR TITLE
Clarify write-mode token scope requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,6 +336,8 @@ Recommended scopes:
 
 Notes:
 
+- `ENABLE_WRITE_TOOLS=true` only enables the MCP server's write-capable tools. It does not add GitLab permissions to the configured token.
+- If write tools are enabled but GitLab returns `insufficient_scope`, the MCP write-mode guard has passed and the token is still missing the required GitLab scope, usually `api`.
 - Project and group access tokens work when their scopes match the requested resources.
 - Some self-managed GitLab instances work better with `GITLAB_TOKEN_HEADER_MODE=private-token`.
 - Keep write and destructive modes off unless you explicitly need them.
@@ -399,6 +401,7 @@ If you want agents and other developers to discover the right tools quickly, ref
 - Run `gitlab-mcp-server doctor` first when setup behavior is unclear.
 - `401 Unauthorized`: the token is invalid, expired, or using the wrong header mode.
 - `403 Forbidden`: the token lacks access or the resource is outside the configured allowlists.
+- `403 insufficient_scope` on write tools after `ENABLE_WRITE_TOOLS=true`: write mode is enabled, but the GitLab credential is still not authorized for writes. Use `gitlab_validate_token` or `doctor`; personal access tokens should show `api` in their scopes. For project, group, or OAuth tokens, verify the token scope and project membership directly in GitLab because PAT scope introspection may be unavailable.
 - `404 Not Found`: the resource is missing or hidden by GitLab permissions.
 - `429 Too Many Requests`: the GitLab rate limit was hit.
 - PAT about to expire: the `doctor` report and `gitlab_validate_token` advisory will flag short remaining lifetime when PAT introspection is available.

--- a/docs/security-model.md
+++ b/docs/security-model.md
@@ -49,6 +49,8 @@ Write operations require:
 3. Minimum GitLab access level check in-server
 4. GitLab API permission check on execution
 
+Write mode is only the MCP server-side feature gate. It does not expand the configured GitLab credential. If a write tool reaches GitLab and returns `insufficient_scope`, the MCP write guard has already passed and the token itself lacks the required GitLab scope, usually `api` for write-capable REST or GraphQL operations.
+
 Destructive operations require:
 
 1. Destructive mode enabled

--- a/docs/tool-design.md
+++ b/docs/tool-design.md
@@ -26,6 +26,7 @@ Common error handling:
 
 - `401`: invalid or expired token
 - `403`: permission denied
+- `403` with `insufficient_scope`: write-mode guard has passed, but the configured GitLab token does not have the required scope for the requested write, usually `api`
 - `404`: project/group/resource not found or private
 - `409`: state conflict or SHA mismatch
 - `422`: validation error

--- a/examples/clients/README.md
+++ b/examples/clients/README.md
@@ -26,6 +26,12 @@ That report confirms:
 - allowlists, denylist, and alias counts
 - likely blocked capabilities and recommended next checks
 
+Important write-mode distinction:
+
+- `ENABLE_WRITE_TOOLS=true` only opens the MCP server's write-tool guard.
+- Normal GitLab writes still require a write-capable GitLab token and project permission.
+- If write tools return `insufficient_scope`, tell the user the MCP write guard is no longer blocking them; the configured GitLab credential is missing the required scope, usually `api`.
+
 Optional aliases for any client:
 
 ```bash


### PR DESCRIPTION
## Summary

Clarifies that `ENABLE_WRITE_TOOLS=true` only enables the MCP server write-tool guard and does not grant GitLab write permissions.

Adds guidance for `403 insufficient_scope` failures so users and AI agents can quickly identify that the GitLab credential likely lacks `api` scope or project write permission.

## Changes

- Documented the write-mode versus GitLab-token permission distinction.
- Added troubleshooting guidance for write tools returning `insufficient_scope`.
- Added agent-facing client setup guidance.
- Mirrored the rule in security and tool design docs.

## Testing

Docs-only change; tests were not run.